### PR TITLE
feat(auth): implement user login and JWT issuance (#5)

### DIFF
--- a/src/main/java/com/Voice/Aerius/Auth/controller/AuthController.java
+++ b/src/main/java/com/Voice/Aerius/Auth/controller/AuthController.java
@@ -1,17 +1,27 @@
 package com.Voice.Aerius.Auth.controller;
 
-import com.Voice.Aerius.Auth.service.AuthService;
-import com.Voice.Aerius.Auth.dto.UserData;
+import com.Voice.Aerius.entity.LoginData;
+import com.Voice.Aerius.entity.UserData;
+import com.Voice.Aerius.Auth.dto.request.LoginRequestDto;
 import com.Voice.Aerius.Auth.dto.request.UserRegistrationRequest;
 import com.Voice.Aerius.Auth.dto.response.UserResponse;
+import com.Voice.Aerius.Auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -24,11 +34,51 @@ public class AuthController {
     @PostMapping("/register")
     @Operation(
             summary = "Register a new user",
-            description = "Creates a new user account with an email and a password. The password is securely hashed before storing."
+            description = "Creates a new user account with an email and a password. The password is securely hashed before storing.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "User registered successfully",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = UserResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Bad Request - Invalid input data"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Not Found - User with this email already exists"
+                    )
+            }
     )
-    public ResponseEntity<UserResponse<UserData>> register(@Valid @RequestBody UserRegistrationRequest request){
-      return ResponseEntity.status(HttpStatus.CREATED).body(authService.signup(request));
-        }
+    public ResponseEntity<UserResponse<UserData>> register(@Valid @RequestBody UserRegistrationRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(authService.signup(request));
     }
 
-
+    @PostMapping("/login")
+    @Operation(
+            summary = "User Login",
+            description = "Authenticates a user with email and password, returning user data if successful.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "User logged in successfully",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = UserResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Forbidden - Invalid credentials or user not found"
+                    )
+            }
+    )
+    public ResponseEntity<UserResponse<LoginData>> login(@Valid @RequestBody LoginRequestDto request) {
+        log.info("Login attempt for user: {}", request.email());
+        return ResponseEntity.status(HttpStatus.OK).body(authService.login(request));
+    }
+}

--- a/src/main/java/com/Voice/Aerius/Auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/Voice/Aerius/Auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,19 @@
+package com.Voice.Aerius.Auth.dto.request;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record LoginRequestDto(
+        @NotNull(message = "Email is required")
+        @Email(message = "Email should be valid")
+        String email,
+
+        @NotNull(message = "Password is required")
+        @Schema(description = "Password of the registered user", example = "P@ssw0rd123")
+        String password
+) {
+}

--- a/src/main/java/com/Voice/Aerius/Auth/impl/EmailServiceImpl.java
+++ b/src/main/java/com/Voice/Aerius/Auth/impl/EmailServiceImpl.java
@@ -1,0 +1,4 @@
+package com.Voice.Aerius.Auth.impl;
+
+public class EmailServiceImpl {
+}

--- a/src/main/java/com/Voice/Aerius/Auth/impl/LoginServiceImpl.java
+++ b/src/main/java/com/Voice/Aerius/Auth/impl/LoginServiceImpl.java
@@ -1,0 +1,71 @@
+package com.Voice.Aerius.Auth.impl;
+
+import com.Voice.Aerius.Auth.dto.request.LoginRequestDto;
+import com.Voice.Aerius.Auth.dto.response.UserResponse;
+import com.Voice.Aerius.Auth.interfaces.LoginService;
+import com.Voice.Aerius.Auth.model.User;
+import com.Voice.Aerius.Auth.repository.UserRepository;
+import com.Voice.Aerius.entity.LoginData;
+import com.Voice.Aerius.exceptions.customexceptions.ForbiddenException;
+import com.Voice.Aerius.exceptions.customexceptions.NotFoundException;
+import com.Voice.Aerius.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginServiceImpl implements LoginService {
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResponse<LoginData> login(LoginRequestDto request) {
+        Optional<User> user = userRepository.findByEmail(request.email());
+
+        if (user.isEmpty()) {
+            throw new NotFoundException("User not found with email: " + request.email());
+        }
+
+        Authentication authentication;
+        try {
+            authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.email(), request.password())
+            );
+        } catch (AuthenticationException e) {
+            throw new ForbiddenException("Authentication failed. Please check your credentials.");
+        }
+
+        User authenticatedUser = (User) authentication.getPrincipal();
+
+        String accessToken = jwtTokenProvider.generateAccessToken(authenticatedUser);
+
+        LoginData loginData = LoginData.builder()
+                .id(authenticatedUser.getId())
+                .firstName(authenticatedUser.getFirstName())
+                .lastName(authenticatedUser.getLastName())
+                .email(authenticatedUser.getEmail())
+                .role(authenticatedUser.getRole())
+                .accessToken(accessToken)
+                .isVerified(authenticatedUser.isVerified())
+                .createdAt(authenticatedUser.getCreatedAt())
+                .updatedAt(authenticatedUser.getUpdatedAt())
+                .build();
+
+        return UserResponse.<LoginData>builder()
+                .statusCode(HttpStatus.OK.value())
+                .status("success")
+                .message("User logged in successfully")
+                .data(loginData)
+                .build();
+    }
+}

--- a/src/main/java/com/Voice/Aerius/Auth/impl/SignUpImpl.java
+++ b/src/main/java/com/Voice/Aerius/Auth/impl/SignUpImpl.java
@@ -4,7 +4,7 @@ import com.Voice.Aerius.Auth.enums.Role;
 import com.Voice.Aerius.Auth.interfaces.SignAuthService;
 import com.Voice.Aerius.Auth.model.User;
 import com.Voice.Aerius.Auth.repository.UserRepository;
-import com.Voice.Aerius.Auth.dto.UserData;
+import com.Voice.Aerius.entity.UserData;
 import com.Voice.Aerius.Auth.dto.request.UserRegistrationRequest;
 import com.Voice.Aerius.Auth.dto.response.UserResponse;
 import com.Voice.Aerius.exceptions.customexceptions.ConflictException;

--- a/src/main/java/com/Voice/Aerius/Auth/interfaces/LoginService.java
+++ b/src/main/java/com/Voice/Aerius/Auth/interfaces/LoginService.java
@@ -1,0 +1,10 @@
+package com.Voice.Aerius.Auth.interfaces;
+
+import com.Voice.Aerius.Auth.dto.request.LoginRequestDto;
+import com.Voice.Aerius.Auth.dto.response.UserResponse;
+import com.Voice.Aerius.entity.LoginData;
+
+public interface LoginService {
+    UserResponse<LoginData> login(LoginRequestDto request);
+}
+

--- a/src/main/java/com/Voice/Aerius/Auth/interfaces/SignAuthService.java
+++ b/src/main/java/com/Voice/Aerius/Auth/interfaces/SignAuthService.java
@@ -1,6 +1,6 @@
 package com.Voice.Aerius.Auth.interfaces;
 
-import com.Voice.Aerius.Auth.dto.UserData;
+import com.Voice.Aerius.entity.UserData;
 import com.Voice.Aerius.Auth.dto.request.UserRegistrationRequest;
 import com.Voice.Aerius.Auth.dto.response.UserResponse;
 

--- a/src/main/java/com/Voice/Aerius/Auth/service/AuthService.java
+++ b/src/main/java/com/Voice/Aerius/Auth/service/AuthService.java
@@ -1,7 +1,10 @@
 package com.Voice.Aerius.Auth.service;
 
+import com.Voice.Aerius.Auth.dto.request.LoginRequestDto;
+import com.Voice.Aerius.Auth.interfaces.LoginService;
 import com.Voice.Aerius.Auth.interfaces.SignAuthService;
-import com.Voice.Aerius.Auth.dto.UserData;
+import com.Voice.Aerius.entity.LoginData;
+import com.Voice.Aerius.entity.UserData;
 import com.Voice.Aerius.Auth.dto.request.UserRegistrationRequest;
 import com.Voice.Aerius.Auth.dto.response.UserResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +14,14 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthService{
     private final SignAuthService signAuthService;
+    private final LoginService loginService;
+
 
     public  UserResponse<UserData> signup(UserRegistrationRequest regrequest){
         return signAuthService.signup(regrequest);
    }
+
+    public UserResponse<LoginData> login(LoginRequestDto request) {
+        return loginService.login(request);
+    }
 }

--- a/src/main/java/com/Voice/Aerius/entity/LoginData.java
+++ b/src/main/java/com/Voice/Aerius/entity/LoginData.java
@@ -1,0 +1,20 @@
+package com.Voice.Aerius.entity;
+
+import com.Voice.Aerius.Auth.enums.Role;
+import lombok.Builder;
+
+import java.time.OffsetDateTime;
+
+@Builder
+public record LoginData (
+        String id,
+        String firstName,
+        String lastName,
+        String email,
+        Role role,
+        boolean isVerified,
+        String accessToken,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+){
+}

--- a/src/main/java/com/Voice/Aerius/entity/UserData.java
+++ b/src/main/java/com/Voice/Aerius/entity/UserData.java
@@ -1,4 +1,4 @@
-package com.Voice.Aerius.Auth.dto;
+package com.Voice.Aerius.entity;
 
 import com.Voice.Aerius.Auth.enums.Role;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
### Summary
Implemented user login functionality as described in Issue #5. Authenticated users receive a signed JWT upon successful login.

### What Was Done
- Created POST `/api/auth/login` endpoint
- Validated user credentials using Spring Security and `AuthenticationManager`
- Compared hashed passwords using `BCryptPasswordEncoder`
- Integrated `JwtTokenProvider` to issue JWT tokens
- Returned token in the response body
- Handled invalid credentials with appropriate error response (401 Unauthorized)

### Sample Request
```json
POST /api/auth/login
{
  "email": "user@example.com",
  "password": "securePassword123"
}


### Sample Response
```json
{
  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
}
